### PR TITLE
make carved obj limit configurable per submission

### DIFF
--- a/pdf_id/pdf_id.py
+++ b/pdf_id/pdf_id.py
@@ -18,8 +18,6 @@ from assemblyline_v4_service.common.request import MaxExtractedExceeded
 class PDFId(ServiceBase):
     def __init__(self, config=None):
         super(PDFId, self).__init__(config)
-        # Define a threshold for carved objects to meet before being added to submission
-        self.carved_obj_limit = 750
 
     @staticmethod
     def get_pdfid(path, additional_keywords, plugins, deep):
@@ -505,6 +503,7 @@ class PDFId(ServiceBase):
                 show_content_of_interest = True
 
             if len(carved_content) > 0:
+                carved_obj_size_limit = request.get_param('carved_obj_size_limit')
                 for k, l in sorted(carved_content.items()):
                     for d in l:
                         for keyw, con in d.items():
@@ -512,7 +511,7 @@ class PDFId(ServiceBase):
                             subres.set_heuristic(8)
 
                             con_bytes = con.encode()
-                            if len(con) < self.carved_obj_limit:
+                            if len(con) < carved_obj_size_limit:
                                 subres.body_format = BODY_FORMAT.MEMORY_DUMP
                                 subres.add_line(con)
 
@@ -538,7 +537,7 @@ class PDFId(ServiceBase):
                                 if crv_sha not in carved_extracted_shas:
                                     f_name = f"carved_content_obj_{k}_{crv_sha[0:7]}"
                                     subres.add_lines(
-                                        [f"Content over {self.carved_obj_limit} bytes it will be extracted {extraction_purpose}",
+                                        [f"Content over {carved_obj_size_limit} bytes it will be extracted {extraction_purpose}",
                                          f"Name: {f_name} - SHA256: {crv_sha}"])
                                     carres.add_subsection(subres)
                                     show_content_of_interest = True
@@ -805,7 +804,6 @@ class PDFId(ServiceBase):
         """Main Module. See README for details."""
         max_size = self.config.get('MAX_PDF_SIZE', 3000000)
         request.result = result = Result()
-        self.carved_obj_limit = request.get_param('carved_obj_size_limit')
         if (os.path.getsize(request.file_path) or 0) < max_size or request.deep_scan:
             path = request.file_path
             working_dir = self.working_directory

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -17,6 +17,12 @@ enabled: true
 is_external: false
 licence_count: 0
 
+submission_params:
+  - default: 750
+    name: "carved_obj_size_limit"
+    value: 750
+    type: int
+
 config:
   ADDITIONAL_KEYS: ['/URI', '/GoToE', '/GoToR', '/XObject']
   HEURISTICS: ['pdf_id/pdfid/plugin_embeddedfile', 'pdf_id/pdfid/plugin_nameobfuscation', 'pdf_id/pdfid/plugin_suspicious_properties', 'pdf_id/pdfid/plugin_triage']


### PR DESCRIPTION
Since we don't know what's a good way to limit the number of files to includes (yet), we can make the parameter configurable to avoid too many carved objects to get added to the submission.

This way we can maintain control if we need to overall or leave it up to the user until we can come up with a smarter fix.